### PR TITLE
Add C++ implementation for fast unique/count in some cases (~10x)

### DIFF
--- a/simple_ans/cpp/simple_ans.hpp
+++ b/simple_ans/cpp/simple_ans.hpp
@@ -77,19 +77,18 @@ std::tuple<std::vector<T>, std::vector<uint64_t>> unique_with_counts(const T* va
 
     if ((max_value - min_value + 1) <= lookup_array_threshold)
     {
-        counts.resize(max_value - min_value + 1);
+        std::vector<uint64_t> raw_counts(max_value - min_value + 1);
         for (size_t i = 0; i < n; ++i)
         {
-            counts[values[i] - min_value]++;
+            raw_counts[values[i] - min_value]++;
         }
 
-        std::vector<uint64_t> nonzero_counts;
         for (size_t i = 0; i < counts.size(); ++i)
         {
-            if (counts[i])
+            if (raw_counts[i])
             {
                 unique_values.push_back(static_cast<T>(i + min_value));
-                nonzero_counts.push_back(counts[i]);
+                counts.push_back(raw_counts[i]);
             }
         }
     }

--- a/simple_ans/cpp/simple_ans.hpp
+++ b/simple_ans/cpp/simple_ans.hpp
@@ -51,7 +51,7 @@ void ans_decode_t(T* output,
 
 namespace simple_ans
 {
-constexpr int lookup_array_threshold = std::numeric_limits<uint16_t>::max();
+constexpr int lookup_array_threshold = std::numeric_limits<uint16_t>::max() + 1;
 
 template <typename T>
 std::tuple<std::vector<T>, std::vector<uint64_t>> unique_with_counts(const T* values, size_t n)

--- a/simple_ans/encode_decode.py
+++ b/simple_ans/encode_decode.py
@@ -36,7 +36,9 @@ def _ans_unique(arr: np.ndarray):
     else:
         raise TypeError("Invalid numpy type")
 
-    if not len(vals) or not len(counts):
+    assert len(vals) == len(counts)
+
+    if not len(vals):
         vals, counts = np.unique(arr, return_counts=True)
 
     return vals, counts

--- a/simple_ans/encode_decode.py
+++ b/simple_ans/encode_decode.py
@@ -5,15 +5,41 @@ from .choose_symbol_counts import choose_symbol_counts
 from ._simple_ans import (
     ans_encode_int16 as _ans_encode_int16,
     ans_decode_int16 as _ans_decode_int16,
+    ans_unique_int16 as _ans_unique_int16,
     ans_encode_int32 as _ans_encode_int32,
     ans_decode_int32 as _ans_decode_int32,
+    ans_unique_int32 as _ans_unique_int32,
     ans_encode_uint16 as _ans_encode_uint16,
     ans_decode_uint16 as _ans_decode_uint16,
+    ans_unique_uint16 as _ans_unique_uint16,
     ans_encode_uint32 as _ans_encode_uint32,
     ans_decode_uint32 as _ans_decode_uint32,
+    ans_unique_uint32 as _ans_unique_uint32,
     ans_encode_uint8 as _ans_encode_uint8,
     ans_decode_uint8 as _ans_decode_uint8,
+    ans_unique_uint8 as _ans_unique_uint8,
 )
+
+
+def _ans_unique(arr: np.ndarray):
+    dtype = arr.dtype
+    if dtype == np.int32:
+        vals, counts = _ans_unique_int32(arr)
+    elif dtype == np.int16:
+        vals, counts = _ans_unique_int16(arr)
+    elif dtype == np.uint32:
+        vals, counts = _ans_unique_uint32(arr)
+    elif dtype == np.uint8:
+        vals, counts = _ans_unique_uint8(arr)
+    elif dtype == np.uint16:
+        vals, counts = _ans_unique_uint16(arr)
+    else:
+        raise TypeError("Invalid numpy type")
+
+    if not len(vals) or not len(counts):
+        vals, counts = np.unique(arr, return_counts=True)
+
+    return vals, counts
 
 
 def ans_encode(signal: np.ndarray, *, index_size: Union[int, None] = None, verbose=False) -> EncodedSignal:
@@ -36,7 +62,7 @@ def ans_encode(signal: np.ndarray, *, index_size: Union[int, None] = None, verbo
     assert signal.ndim == 1, "Input signal must be a 1D array"
 
     signal_length = len(signal)
-    vals, counts = np.unique(signal, return_counts=True)
+    vals, counts = _ans_unique(signal)
     vals = np.array(vals, dtype=signal.dtype)
     probs = counts / np.sum(counts)
 

--- a/simple_ans_bind.cpp
+++ b/simple_ans_bind.cpp
@@ -1,7 +1,9 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <cstdint>
 #include <cstring>  // for memcpy
+
 #include "simple_ans/cpp/simple_ans.hpp"
 
 namespace py = pybind11;
@@ -12,6 +14,17 @@ void bind_ans_functions(py::module& m, const char* type_suffix)
 {
     std::string ans_encode_name = std::string("ans_encode_") + type_suffix;
     std::string ans_decode_name = std::string("ans_decode_") + type_suffix;
+    std::string ans_unique_name = std::string("ans_unique_") + type_suffix;
+
+    m.def(
+        ans_unique_name.c_str(),
+        [](py::array_t<T> signal)
+        {
+            py::buffer_info buf = signal.request();
+            return simple_ans::unique_with_counts(static_cast<const T*>(buf.ptr), buf.size);
+        },
+        "Get unique values and their counts",
+        py::arg("signal").noconvert());
 
     m.def(
         ans_encode_name.c_str(),


### PR DESCRIPTION
This PR introduces a fast variant of `np.unique` for arrays with a narrow domain width (less than `65536`). This also bumps the table lookup size to `65536` for the symbol index lookup. For the test cases, this shifted the encoding bottleneck back to the encoder, and off of the `np.unique` call. Any types using 16 bits or less will automatically benefit, and narrow banded 32 bit data should also be accelerated. Wide domain data will suffer a very small performance hit, since the whole array needs to be scanned once.