### PR TITLE
benchmark blosc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest"]
-benchmark = ["matplotlib", "zstandard"]
+benchmark = ["matplotlib", "zstandard", "blosc2"]
 
 [tool.scikit-build]
 cmake.version = ">=3.15"


### PR DESCRIPTION
Hi @magland,

In case you're interested, I added blosc2 to `benchmark.py`. It gets good compression (6.37x), but not as good as simple_ans (7.13x)! It does better than the other methods, though. Perhaps it's an interesting data point to add, since blosc is fairly widely used for scientific/numeric data compression. But this was mostly to satisfy by curiosity, so feel free to ignore this.

It's also interesting to note that blosc only needs the lowest level of Zstandard compression to get this performance. The bit-wise transpose exposes a lot of compression opportunities to Zstandard, apparently. I did manually tune the blocksize a bit to get better compression at the expense of some speed, though.