### PR TITLE
extended blosc benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ While there are certainly many ANS implementations that are parts of other packa
 
 simple_ans is available on PyPI:
 
-```console
+```
 pip install simple-ans
 ```
 
 Developers may want to clone the repository and do an editable install:
 
-```console
+```
 git clone https://github.com/flatironinstitute/simple_ans.git
 cd simple_ans
 pip install -e .
@@ -31,7 +31,7 @@ pip install -e .
 
 For developers who want automatic rebuilds of the compiled extension:
 
-```console
+```
 pip install "scikit-build-core>=0.5.0" "pybind11>=2.11.1" "pip>=24" ninja
 pip install -e . -Ceditable.rebuild=true --no-build-isolation
 ```
@@ -69,24 +69,24 @@ print(f"Compression ratio: {compression_ratio:.2f}x")
 ## Tests
 To run the tests, install with the `test` extra and run `pytest`:
 
-```console
+```
 pip install "simple-ans[test]"
 pytest tests/
 ```
 
 ## Simple benchmark
 
-You can run a very simple benchmark that compares simple_ans with `zlib`, `zstandard`, and `lzma` at various compression levels for a toy dataset of quantized Gaussian noise. See [devel/benchmark.py](./devel/benchmark.py) and [devel/benchmark_ans_only.py](./devel/benchmark_ans_only.py).
+You can run a very simple benchmark that compares simple_ans with `zlib`, `zstandard`, `lzma`, and `blosc2` at various compression levels for a toy dataset of quantized Gaussian noise. See [devel/benchmark.py](./devel/benchmark.py) and [devel/benchmark_ans_only.py](./devel/benchmark_ans_only.py).
 
 The benchmark.py also runs in a CI environment and produces the following graph:
 
 ![Benchmark](https://github.com/magland/simple_ans/blob/benchmark-results/benchmark-results/benchmark.png?raw=true)
 
-We see that for this example, the ANS-based compression ratio is higher than the other methods, almost reaching the theoretical ideal. The encode rate in MB/s is also fastest for simple_ans. The decode rate is faster than Zlib but slower than Zstandard. I think in principle, we should be able to speed up the decoding. Let me know if you have ideas for this.
+We see that for this example, the ANS-based compression ratio is higher than the other methods, almost reaching the theoretical ideal. The encode rate in MB/s is also faster than all but blosc. The decode rate is faster than Zlib and lzma but slower than Zstandard or blosc. I think in principle, we should be able to speed up the decoding. Let me know if you have ideas for this.
 
 To install the benchmark dependencies, use:
 
-```console
+```
 pip install .[benchmark]
 ```
 
@@ -98,7 +98,7 @@ A more comprehensive benchmark ([devel/benchmark2.py](./devel/benchmark2.py)) te
 * Quantized Gaussian distributions with different quantization steps
 * Poisson distributions with various lambda parameters
 
-The benchmark compares simple_ans against zstd-22 and zlib-9, measuring compression ratios and processing speeds:
+The benchmark compares simple_ans against zstd-22, zlib-9, and blosc (using bitshuffle, zstd-1, and 2 MiB blocks), measuring compression ratios and processing speeds:
 
 ![Compression Ratios](https://github.com/magland/simple_ans/blob/benchmark-results/benchmark-results/benchmark2_compression_ratio.png?raw=true)
 
@@ -106,7 +106,7 @@ The benchmark compares simple_ans against zstd-22 and zlib-9, measuring compress
 
 ![Decode Speeds](https://github.com/magland/simple_ans/blob/benchmark-results/benchmark-results/benchmark2_decode_rate.png?raw=true)
 
-The results show that simple_ans consistently achieves compression ratios close to the theoretical ideal across all distributions, while maintaining competitive processing speeds.
+The results show that simple_ans achieves the overall highest compression ratios—close to the theoretical ideal across all distributions. The encode speed is faster than all but blosc. blosc typically achieves the highest encode and decode speeds and the second-highest compression ratios.
 
 ## Authors
 

--- a/devel/benchmark.py
+++ b/devel/benchmark.py
@@ -207,6 +207,7 @@ print()
 import blosc2
 
 timer = time.time()
+blosc2.set_nthreads(1)
 blosc2.set_blocksize(1<<21)
 compressed = blosc2.compress(signal, codec=blosc2.Codec.ZSTD, clevel=1, filter=blosc2.Filter.BITSHUFFLE)
 elapsed_blosc = time.time() - timer


### PR DESCRIPTION
Here's the version of `benchmark2.py` updated with blosc. I updated the readme as well.

I think my only question is whether the encode speed plots should be on a log scale or similar to deal with the dynamic range. All the other plots are linear scale, though. Any thoughts on that?